### PR TITLE
NFR-3: Simple UI [AUTH]

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,9 +3,11 @@ import reactLogo from './assets/react.svg'
 import viteLogo from './assets/vite.svg'
 import heroImg from './assets/hero.png'
 import './App.css'
+import { AuthProvider, useAuth } from './auth/AuthContext'
+import LoginPage from './pages/LoginPage'
+import SignupPage from './pages/SignupPage'
 
-// Define the Event type for TypeScript
-interface Event {
+interface EventItem {
   id: number;
   title: string;
   category: string;
@@ -13,12 +15,13 @@ interface Event {
   eventDatetime: string;
 }
 
-function App() {
-  const [events, setEvents] = useState<Event[]>([]);
+function AppContent() {
+  const { isAuthenticated, user, logout } = useAuth();
+  const [currentPage, setCurrentPage] = useState<string>('events');
+  const [events, setEvents] = useState<EventItem[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    // Fetch from your Spring Boot Backend
     fetch('http://localhost:8080/api/events')
       .then(res => res.json())
       .then(data => {
@@ -31,8 +34,35 @@ function App() {
       });
   }, []);
 
+  if (currentPage === 'login') {
+    return <LoginPage onNavigate={(page) => setCurrentPage(page)} />;
+  }
+
+  if (currentPage === 'signup') {
+    return <SignupPage onNavigate={(page) => setCurrentPage(page)} />;
+  }
+
   return (
     <>
+      <nav style={{ padding: '10px 20px', background: '#1a1a1a', display: 'flex', gap: '16px', alignItems: 'center' }}>
+        <button onClick={() => setCurrentPage('events')}>Browse Events</button>
+        {isAuthenticated ? (
+          <>
+            <button onClick={() => setCurrentPage('reservations')}>My Reservations</button>
+            {user?.role === 'ADMIN' && (
+              <button onClick={() => setCurrentPage('admin')}>Admin Dashboard</button>
+            )}
+            <span style={{ marginLeft: 'auto', fontSize: '0.85em' }}>{user?.email}</span>
+            <button onClick={logout}>Logout</button>
+          </>
+        ) : (
+          <>
+            <button onClick={() => setCurrentPage('login')}>Log In</button>
+            <button onClick={() => setCurrentPage('signup')}>Sign Up</button>
+          </>
+        )}
+      </nav>
+
       <section id="center">
         <div className="hero">
           <img src={heroImg} className="base" width="170" height="179" alt="" />
@@ -75,6 +105,14 @@ function App() {
       <section id="spacer"></section>
     </>
   )
+}
+
+function App() {
+  return (
+    <AuthProvider>
+      <AppContent />
+    </AuthProvider>
+  );
 }
 
 export default App

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -5,7 +5,7 @@ import App from '../App';
 describe('App Component', () => {
   it('should render the Browse Events title', () => {
     render(<App />);
-    const titleElement = screen.getByText(/Browse Events/i);
+    const titleElement = screen.getByRole('heading', { name: /Browse Events/i, level: 1 });
     expect(titleElement).toBeInTheDocument();
   });
 

--- a/frontend/src/__tests__/LoginPage.test.tsx
+++ b/frontend/src/__tests__/LoginPage.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import LoginPage from '../pages/LoginPage';
+import { AuthProvider } from '../auth/AuthContext';
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('should render login form', () => {
+    render(
+      <AuthProvider>
+        <LoginPage onNavigate={() => {}} />
+      </AuthProvider>
+    );
+
+    expect(screen.getByPlaceholderText(/email/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/password/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /log in/i })).toBeInTheDocument();
+  });
+
+  it('should show error on invalid credentials', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: 'Invalid email or password' }),
+    }));
+
+    render(
+      <AuthProvider>
+        <LoginPage onNavigate={() => {}} />
+      </AuthProvider>
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/email/i), {
+      target: { value: 'wrong@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/password/i), {
+      target: { value: 'badpassword' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /log in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid email or password/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should store token in localStorage on successful login', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ token: 'test.jwt.token', message: 'Login successful' }),
+    }));
+
+    const onNavigate = vi.fn();
+
+    render(
+      <AuthProvider>
+        <LoginPage onNavigate={onNavigate} />
+      </AuthProvider>
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/email/i), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/password/i), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /log in/i }));
+
+    await waitFor(() => {
+      expect(localStorage.getItem('token')).toBe('test.jwt.token');
+    });
+  });
+});

--- a/frontend/src/__tests__/SignupPage.test.tsx
+++ b/frontend/src/__tests__/SignupPage.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import SignupPage from '../pages/SignupPage';
+import { AuthProvider } from '../auth/AuthContext';
+
+describe('SignupPage', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('should render signup form', () => {
+    render(
+      <AuthProvider>
+        <SignupPage onNavigate={() => {}} />
+      </AuthProvider>
+    );
+
+    expect(screen.getByPlaceholderText(/email/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/phone/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/password/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /sign up/i })).toBeInTheDocument();
+  });
+
+  it('should show error on duplicate email', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({ error: 'Email already in use' }),
+    }));
+
+    render(
+      <AuthProvider>
+        <SignupPage onNavigate={() => {}} />
+      </AuthProvider>
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/email/i), {
+      target: { value: 'existing@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/password/i), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /sign up/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/already in use/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should succeed on valid signup', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ message: 'User registered successfully' }),
+    }));
+
+    const onNavigate = vi.fn();
+
+    render(
+      <AuthProvider>
+        <SignupPage onNavigate={onNavigate} />
+      </AuthProvider>
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/email/i), {
+      target: { value: 'new@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/password/i), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /sign up/i }));
+
+    await waitFor(() => {
+      expect(onNavigate).toHaveBeenCalledWith('login');
+    });
+  });
+});

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -1,0 +1,62 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+export interface User {
+  email: string;
+  role: string;
+}
+
+interface AuthContextType {
+  user: User | null;
+  token: string | null;
+  isAuthenticated: boolean;
+  login: (token: string) => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | null>(null);
+
+function decodeToken(token: string): User {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return { email: '', role: 'CUSTOMER' };
+    const payload = JSON.parse(atob(parts[1]));
+    return {
+      email: payload.sub || '',
+      role: payload.role || 'CUSTOMER',
+    };
+  } catch {
+    return { email: '', role: 'CUSTOMER' };
+  }
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [token, setToken] = useState<string | null>(() => localStorage.getItem('token'));
+  const [user, setUser] = useState<User | null>(() => {
+    const stored = localStorage.getItem('token');
+    return stored ? decodeToken(stored) : null;
+  });
+
+  function login(newToken: string) {
+    localStorage.setItem('token', newToken);
+    setToken(newToken);
+    setUser(decodeToken(newToken));
+  }
+
+  function logout() {
+    localStorage.removeItem('token');
+    setToken(null);
+    setUser(null);
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, token, isAuthenticated: !!token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextType {
+  const context = useContext(AuthContext);
+  if (!context) throw new Error('useAuth must be used within an AuthProvider');
+  return context;
+}

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, ReactNode } from 'react';
+import { createContext, useContext, useState, type ReactNode } from 'react';
 
 export interface User {
   email: string;

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { useAuth } from '../auth/AuthContext';
+
+interface LoginPageProps {
+  onNavigate: (page: string) => void;
+}
+
+export default function LoginPage({ onNavigate }: LoginPageProps) {
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await fetch('http://localhost:8080/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        login(data.token);
+        onNavigate('events');
+      } else {
+        setError(data.error || 'Invalid email or password');
+      }
+    } catch {
+      setError('Something went wrong. Please try again.');
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: '400px', margin: '60px auto', padding: '20px' }}>
+      <h2>Log In</h2>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+        <input
+          type="text"
+          placeholder="Email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        {error && <p style={{ color: '#ff6b6b', margin: 0 }}>{error}</p>}
+        <button type="submit">Log In</button>
+      </form>
+      <p style={{ marginTop: '16px' }}>
+        Don't have an account?{' '}
+        <button type="button" onClick={() => onNavigate('signup')}>Sign Up</button>
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+
+interface SignupPageProps {
+  onNavigate: (page: string) => void;
+}
+
+export default function SignupPage({ onNavigate }: SignupPageProps) {
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    if (!email && !phone) {
+      setError('Please provide at least an email or phone number.');
+      return;
+    }
+    try {
+      const res = await fetch('http://localhost:8080/api/auth/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: email || null,
+          phone: phone || null,
+          password,
+        }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        onNavigate('login');
+      } else {
+        setError(data.error || 'Signup failed. Please try again.');
+      }
+    } catch {
+      setError('Something went wrong. Please try again.');
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: '400px', margin: '60px auto', padding: '20px' }}>
+      <h2>Sign Up</h2>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+        <input
+          type="text"
+          placeholder="Email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+        <input
+          type="text"
+          placeholder="Phone"
+          value={phone}
+          onChange={e => setPhone(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        {error && <p style={{ color: '#ff6b6b', margin: 0 }}>{error}</p>}
+        <button type="submit">Sign Up</button>
+      </form>
+      <p style={{ marginTop: '16px' }}>
+        Already have an account?{' '}
+        <button type="button" onClick={() => onNavigate('login')}>Log In</button>
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
### What's in this PR

This PR adds the complete authentication UI for the frontend. Users can now log in and sign up without going through the backend registration API directly.

### Changes

**New Files:**
- `frontend/src/auth/AuthContext.tsx` - React Context that handles all auth state (user, token, login, logout). Stores JWT in localStorage so users stay logged in.
- `frontend/src/pages/LoginPage.tsx` - Login form with email and password inputs. Makes a POST to /api/auth/login and stores the token if successful.
- `frontend/src/pages/SignupPage.tsx` - Signup form with email, phone, and password. At least one of email or phone is required. Redirects to login on success.
- `frontend/src/__tests__/LoginPage.test.tsx` - 3 tests for login: render check, error handling, and token storage.
- `frontend/src/__tests__/SignupPage.test.tsx` - 3 tests for signup: render check, error on duplicate email, and successful signup.

**Modified Files:**
- `frontend/src/App.tsx` - Refactored to use AuthProvider wrapper and added page navigation with currentPage state. Added navbar with links based on auth status. Shows Browse Events, Log In, and Sign Up when logged out. Shows Browse Events, My Reservations, Admin Dashboard (if admin), and Logout when logged in.

### How Auth Works

1. When someone logs in, the backend returns a JWT token
2. AuthContext decodes the token (just base64, no verification on frontend) to get user email and role
3. Token is stored in localStorage
4. On page reload, the app stays logged in (token persists)
5. When logging out, localStorage is cleared

### Tests

All tests follow TDD: they were written first to fail, then the components were implemented to make them pass. Tests use mocked fetch for API calls.

- LoginPage tests: check form renders, error message shows on 401, token gets stored on 200
- SignupPage tests: check form renders, error shows on 409, redirect to login on 201

### Testing

Run tests with:
```
cd frontend
npm test -- --run
```

All 8 tests pass (2 existing App tests + 3 LoginPage + 3 SignupPage).

### Notes

- Users stay logged in across page reloads because the token is in localStorage
- The navbar updates automatically based on whether the user is logged in
- Admin users will see an Admin Dashboard link (no functionality yet, that's for later)
- Yassine needs this merged before working on the filter UI and booking buttons
