### PR TITLE
Add booking and cancellation email notifications with logging (FR5 AND FR6)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.xerial:sqlite-jdbc:3.50.3.0'
 	implementation 'org.hibernate.orm:hibernate-community-dialects'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/backend/src/main/java/com/soen345/meow/config/MailConfig.java
+++ b/backend/src/main/java/com/soen345/meow/config/MailConfig.java
@@ -1,0 +1,36 @@
+package com.soen345.meow.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+
+    @Bean
+    @ConditionalOnMissingBean(JavaMailSender.class)
+    public JavaMailSender javaMailSender(
+            @Value("${spring.mail.host:sandbox.smtp.mailtrap.io}") String host,
+            @Value("${spring.mail.port:2525}") int port,
+            @Value("${spring.mail.username:}") String username,
+            @Value("${spring.mail.password:}") String password,
+            @Value("${spring.mail.properties.mail.smtp.auth:true}") boolean smtpAuth,
+            @Value("${spring.mail.properties.mail.smtp.starttls.enable:true}") boolean startTls
+    ) {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.smtp.auth", String.valueOf(smtpAuth));
+        props.put("mail.smtp.starttls.enable", String.valueOf(startTls));
+        return mailSender;
+    }
+}

--- a/backend/src/main/java/com/soen345/meow/controller/AdminEventController.java
+++ b/backend/src/main/java/com/soen345/meow/controller/AdminEventController.java
@@ -2,11 +2,18 @@ package com.soen345.meow.controller;
 
 import com.soen345.meow.dto.CreateEventRequest;
 import com.soen345.meow.entity.Event;
+import com.soen345.meow.entity.Reservation;
+import com.soen345.meow.entity.User;
 import com.soen345.meow.repository.EventRepository;
+import com.soen345.meow.repository.ReservationRepository;
+import com.soen345.meow.repository.UserRepository;
+import com.soen345.meow.service.NotificationService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @CrossOrigin(origins = "http://localhost:5173")
 @RestController
@@ -14,9 +21,20 @@ import org.springframework.web.bind.annotation.*;
 public class AdminEventController {
 
     private final EventRepository eventRepository;
+    private final ReservationRepository reservationRepository;
+    private final UserRepository userRepository;
+    private final NotificationService notificationService;
 
-    public AdminEventController(EventRepository eventRepository) {
+    public AdminEventController(
+            EventRepository eventRepository,
+            ReservationRepository reservationRepository,
+            UserRepository userRepository,
+            NotificationService notificationService
+    ) {
         this.eventRepository = eventRepository;
+        this.reservationRepository = reservationRepository;
+        this.userRepository = userRepository;
+        this.notificationService = notificationService;
     }
 
     @PostMapping
@@ -47,7 +65,9 @@ public class AdminEventController {
                 .orElseThrow(() -> new IllegalArgumentException("Event not found"));
 
         event.setStatus("CANCELLED");
-        return ResponseEntity.ok(eventRepository.save(event));
+        Event savedEvent = eventRepository.save(event);
+        notifyConfirmedReservationHolders(savedEvent);
+        return ResponseEntity.ok(savedEvent);
     }
 
     private void applyRequestToEvent(CreateEventRequest request, Event event) {
@@ -56,5 +76,15 @@ public class AdminEventController {
         event.setLocation(request.getLocation());
         event.setEventDatetime(request.getEventDatetime());
         event.setCapacity(request.getCapacity());
+    }
+
+    private void notifyConfirmedReservationHolders(Event event) {
+        List<Reservation> reservations = reservationRepository.findByEventIdAndStatus(event.getId(), "CONFIRMED");
+        for (Reservation reservation : reservations) {
+            userRepository.findById(reservation.getUserId())
+                    .map(User::getEmail)
+                    .filter(email -> email != null && !email.isBlank())
+                    .ifPresent(email -> notificationService.sendEventCancellationNotice(email, event.getTitle()));
+        }
     }
 }

--- a/backend/src/main/java/com/soen345/meow/entity/NotificationLog.java
+++ b/backend/src/main/java/com/soen345/meow/entity/NotificationLog.java
@@ -1,0 +1,95 @@
+package com.soen345.meow.entity;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notification_logs")
+public class NotificationLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String channel;
+
+    @Column(name = "message_type", nullable = false)
+    private String messageType;
+
+    @Column(name = "delivery_status", nullable = false)
+    private String deliveryStatus;
+
+    @Column(nullable = false)
+    private String recipient;
+
+    @Column(name = "event_title")
+    private String eventTitle;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    void onCreate() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public String getMessageType() {
+        return messageType;
+    }
+
+    public void setMessageType(String messageType) {
+        this.messageType = messageType;
+    }
+
+    public String getDeliveryStatus() {
+        return deliveryStatus;
+    }
+
+    public void setDeliveryStatus(String deliveryStatus) {
+        this.deliveryStatus = deliveryStatus;
+    }
+
+    public String getRecipient() {
+        return recipient;
+    }
+
+    public void setRecipient(String recipient) {
+        this.recipient = recipient;
+    }
+
+    public String getEventTitle() {
+        return eventTitle;
+    }
+
+    public void setEventTitle(String eventTitle) {
+        this.eventTitle = eventTitle;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/soen345/meow/repository/NotificationLogRepository.java
+++ b/backend/src/main/java/com/soen345/meow/repository/NotificationLogRepository.java
@@ -1,0 +1,9 @@
+package com.soen345.meow.repository;
+
+import com.soen345.meow.entity.NotificationLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationLogRepository extends JpaRepository<NotificationLog, Long> {
+}

--- a/backend/src/main/java/com/soen345/meow/service/NotificationService.java
+++ b/backend/src/main/java/com/soen345/meow/service/NotificationService.java
@@ -1,0 +1,73 @@
+package com.soen345.meow.service;
+
+import com.soen345.meow.entity.NotificationLog;
+import com.soen345.meow.repository.NotificationLogRepository;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import jakarta.mail.internet.MimeMessage;
+
+import java.time.LocalDateTime;
+
+@Service
+public class NotificationService {
+
+    private final JavaMailSender javaMailSender;
+    private final NotificationLogRepository notificationLogRepository;
+
+    public NotificationService(JavaMailSender javaMailSender, NotificationLogRepository notificationLogRepository) {
+        this.javaMailSender = javaMailSender;
+        this.notificationLogRepository = notificationLogRepository;
+    }
+
+    public void sendBookingConfirmation(String toEmail, String eventTitle, Long reservationId, LocalDateTime eventDate) {
+        if (!StringUtils.hasText(toEmail)) {
+            return;
+        }
+
+        String subject = "Booking Confirmed - " + eventTitle;
+        String html = "<h2>Reservation Confirmed</h2>"
+                + "<p>Event: <b>" + eventTitle + "</b></p>"
+                + "<p>Reservation ID: <b>" + reservationId + "</b></p>"
+                + "<p>Event Date: <b>" + (eventDate == null ? "TBD" : eventDate) + "</b></p>";
+
+        sendEmailAndLog(toEmail, subject, html, eventTitle, "BOOKING_CONFIRMATION");
+    }
+
+    public void sendEventCancellationNotice(String toEmail, String eventTitle) {
+        if (!StringUtils.hasText(toEmail)) {
+            return;
+        }
+
+        String subject = "Event Cancelled - " + eventTitle;
+        String html = "<h2>Event Cancellation Notice</h2>"
+                + "<p>Your booked event <b>" + eventTitle + "</b> has been cancelled.</p>";
+
+        sendEmailAndLog(toEmail, subject, html, eventTitle, "EVENT_CANCELLATION");
+    }
+
+    private void sendEmailAndLog(String toEmail, String subject, String html, String eventTitle, String messageType) {
+        NotificationLog log = new NotificationLog();
+        log.setChannel("EMAIL");
+        log.setMessageType(messageType);
+        log.setRecipient(toEmail);
+        log.setEventTitle(eventTitle);
+
+        try {
+            MimeMessage message = javaMailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true);
+            helper.setTo(toEmail);
+            helper.setSubject(subject);
+            helper.setText(html, true);
+            javaMailSender.send(message);
+            log.setDeliveryStatus("SENT");
+        } catch (MailException | jakarta.mail.MessagingException ex) {
+            log.setDeliveryStatus("FAILED");
+        }
+
+        notificationLogRepository.save(log);
+    }
+}

--- a/backend/src/main/java/com/soen345/meow/service/ReservationService.java
+++ b/backend/src/main/java/com/soen345/meow/service/ReservationService.java
@@ -2,8 +2,10 @@ package com.soen345.meow.service;
 
 import com.soen345.meow.entity.Event;
 import com.soen345.meow.entity.Reservation;
+import com.soen345.meow.entity.User;
 import com.soen345.meow.repository.EventRepository;
 import com.soen345.meow.repository.ReservationRepository;
+import com.soen345.meow.repository.UserRepository;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,10 +18,19 @@ public class ReservationService {
 
     private final ReservationRepository reservationRepository;
     private final EventRepository eventRepository;
+    private final UserRepository userRepository;
+    private final NotificationService notificationService;
 
-    public ReservationService(ReservationRepository reservationRepository, EventRepository eventRepository) {
+    public ReservationService(
+            ReservationRepository reservationRepository,
+            EventRepository eventRepository,
+            UserRepository userRepository,
+            NotificationService notificationService
+    ) {
         this.reservationRepository = reservationRepository;
         this.eventRepository = eventRepository;
+        this.userRepository = userRepository;
+        this.notificationService = notificationService;
     }
 
     @Transactional
@@ -51,7 +62,9 @@ public class ReservationService {
         reservation.setStatus("CONFIRMED");
         reservation.setReservedAt(LocalDateTime.now());
 
-        return reservationRepository.save(reservation);
+        Reservation savedReservation = reservationRepository.save(reservation);
+        sendConfirmationEmail(userId, event, savedReservation);
+        return savedReservation;
     }
 
     @Transactional
@@ -81,5 +94,28 @@ public class ReservationService {
 
     public List<Reservation> getReservationsForUser(Long userId) {
         return reservationRepository.findByUserId(userId);
+    }
+
+    private void sendConfirmationEmail(Long userId, Event event, Reservation reservation) {
+        userRepository.findById(userId)
+                .map(User::getEmail)
+                .filter(email -> email != null && !email.isBlank())
+                .ifPresent(email -> notificationService.sendBookingConfirmation(
+                        email,
+                        event.getTitle(),
+                        reservation.getId(),
+                        parseEventDate(event.getEventDatetime())
+                ));
+    }
+
+    private LocalDateTime parseEventDate(String eventDatetime) {
+        if (eventDatetime == null || eventDatetime.isBlank()) {
+            return null;
+        }
+        try {
+            return LocalDateTime.parse(eventDatetime);
+        } catch (Exception ex) {
+            return null;
+        }
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -18,3 +18,11 @@ jwt.expiration=86400000
 
 # Logging for easier troubleshooting before the deadline
 logging.level.org.hibernate.SQL=DEBUG
+
+# Mailtrap SMTP configuration
+spring.mail.host=sandbox.smtp.mailtrap.io
+spring.mail.port=2525
+spring.mail.username=${MAILTRAP_USERNAME:replace-me}
+spring.mail.password=${MAILTRAP_PASSWORD:replace-me}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true

--- a/backend/src/test/java/com/soen345/meow/AdminEventControllerNotificationTest.java
+++ b/backend/src/test/java/com/soen345/meow/AdminEventControllerNotificationTest.java
@@ -1,0 +1,91 @@
+package com.soen345.meow;
+
+import com.soen345.meow.controller.AdminEventController;
+import com.soen345.meow.entity.Event;
+import com.soen345.meow.entity.Reservation;
+import com.soen345.meow.entity.User;
+import com.soen345.meow.repository.EventRepository;
+import com.soen345.meow.repository.ReservationRepository;
+import com.soen345.meow.repository.UserRepository;
+import com.soen345.meow.service.NotificationService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminEventControllerNotificationTest {
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @InjectMocks
+    private AdminEventController adminEventController;
+
+    @Test
+    void shouldNotifyConfirmedReservationHoldersWhenEventIsCancelled() {
+        Event event = new Event();
+        event.setId(1);
+        event.setTitle("Jazz Night");
+        event.setStatus("ACTIVE");
+
+        Reservation reservation = new Reservation();
+        reservation.setId(10L);
+        reservation.setUserId(5L);
+        reservation.setEventId(1);
+        reservation.setStatus("CONFIRMED");
+
+        User user = new User("customer@example.com", null, "hash", "CUSTOMER");
+
+        when(eventRepository.findById(1)).thenReturn(Optional.of(event));
+        when(reservationRepository.findByEventIdAndStatus(1, "CONFIRMED")).thenReturn(List.of(reservation));
+        when(userRepository.findById(5L)).thenReturn(Optional.of(user));
+        when(eventRepository.save(event)).thenReturn(event);
+
+        adminEventController.cancelEvent(1);
+
+        verify(notificationService).sendEventCancellationNotice("customer@example.com", "Jazz Night");
+    }
+
+    @Test
+    void shouldSkipCancellationEmailWhenUserHasNoEmail() {
+        Event event = new Event();
+        event.setId(1);
+        event.setTitle("Jazz Night");
+        event.setStatus("ACTIVE");
+
+        Reservation reservation = new Reservation();
+        reservation.setId(10L);
+        reservation.setUserId(5L);
+        reservation.setEventId(1);
+        reservation.setStatus("CONFIRMED");
+
+        User user = new User(null, "5141231234", "hash", "CUSTOMER");
+
+        when(eventRepository.findById(1)).thenReturn(Optional.of(event));
+        when(reservationRepository.findByEventIdAndStatus(1, "CONFIRMED")).thenReturn(List.of(reservation));
+        when(userRepository.findById(5L)).thenReturn(Optional.of(user));
+        when(eventRepository.save(event)).thenReturn(event);
+
+        adminEventController.cancelEvent(1);
+
+        verify(notificationService, never()).sendEventCancellationNotice(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString());
+    }
+}

--- a/backend/src/test/java/com/soen345/meow/NotificationServiceTest.java
+++ b/backend/src/test/java/com/soen345/meow/NotificationServiceTest.java
@@ -1,0 +1,96 @@
+package com.soen345.meow;
+
+import com.soen345.meow.entity.NotificationLog;
+import com.soen345.meow.repository.NotificationLogRepository;
+import com.soen345.meow.service.NotificationService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+
+import java.time.LocalDateTime;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private JavaMailSender javaMailSender;
+
+    @Mock
+    private NotificationLogRepository notificationLogRepository;
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    @Test
+    void shouldSendBookingConfirmationEmail() {
+        MimeMessage mimeMessage = new MimeMessage(Session.getInstance(new Properties()));
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        notificationService.sendBookingConfirmation(
+                "customer@example.com",
+                "Jazz Night",
+                101L,
+                LocalDateTime.of(2026, 5, 10, 20, 0)
+        );
+
+        verify(javaMailSender).send(any(MimeMessage.class));
+
+        ArgumentCaptor<NotificationLog> logCaptor = ArgumentCaptor.forClass(NotificationLog.class);
+        verify(notificationLogRepository).save(logCaptor.capture());
+        assertThat(logCaptor.getValue().getMessageType()).isEqualTo("BOOKING_CONFIRMATION");
+        assertThat(logCaptor.getValue().getDeliveryStatus()).isEqualTo("SENT");
+        assertThat(logCaptor.getValue().getChannel()).isEqualTo("EMAIL");
+        assertThat(logCaptor.getValue().getRecipient()).isEqualTo("customer@example.com");
+    }
+
+    @Test
+    void shouldSendCancellationEmail() {
+        MimeMessage mimeMessage = new MimeMessage(Session.getInstance(new Properties()));
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        notificationService.sendEventCancellationNotice("customer@example.com", "Jazz Night");
+
+        verify(javaMailSender).send(any(MimeMessage.class));
+
+        ArgumentCaptor<NotificationLog> logCaptor = ArgumentCaptor.forClass(NotificationLog.class);
+        verify(notificationLogRepository).save(logCaptor.capture());
+        assertThat(logCaptor.getValue().getMessageType()).isEqualTo("EVENT_CANCELLATION");
+        assertThat(logCaptor.getValue().getDeliveryStatus()).isEqualTo("SENT");
+        assertThat(logCaptor.getValue().getChannel()).isEqualTo("EMAIL");
+    }
+
+    @Test
+    void shouldLogFailedBookingConfirmationWhenMailSendFails() {
+        MimeMessage mimeMessage = new MimeMessage(Session.getInstance(new Properties()));
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+        doThrow(new MailException("smtp down") {}).when(javaMailSender).send(any(MimeMessage.class));
+
+        notificationService.sendBookingConfirmation(
+                "customer@example.com",
+                "Jazz Night",
+                201L,
+                LocalDateTime.of(2026, 5, 10, 20, 0)
+        );
+
+        ArgumentCaptor<NotificationLog> logCaptor = ArgumentCaptor.forClass(NotificationLog.class);
+        verify(notificationLogRepository).save(logCaptor.capture());
+        assertThat(logCaptor.getValue().getMessageType()).isEqualTo("BOOKING_CONFIRMATION");
+        assertThat(logCaptor.getValue().getDeliveryStatus()).isEqualTo("FAILED");
+    }
+}

--- a/backend/src/test/java/com/soen345/meow/ReservationServiceTest.java
+++ b/backend/src/test/java/com/soen345/meow/ReservationServiceTest.java
@@ -2,8 +2,11 @@ package com.soen345.meow;
 
 import com.soen345.meow.entity.Event;
 import com.soen345.meow.entity.Reservation;
+import com.soen345.meow.entity.User;
 import com.soen345.meow.repository.EventRepository;
 import com.soen345.meow.repository.ReservationRepository;
+import com.soen345.meow.repository.UserRepository;
+import com.soen345.meow.service.NotificationService;
 import com.soen345.meow.service.ReservationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,6 +22,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,6 +34,12 @@ class ReservationServiceTest {
     @Mock
     private EventRepository eventRepository;
 
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private NotificationService notificationService;
+
     @InjectMocks
     private ReservationService reservationService;
 
@@ -39,13 +49,17 @@ class ReservationServiceTest {
     void setUp() {
         event = new Event();
         event.setId(1);
+        event.setTitle("SOEN Concert");
+        event.setEventDatetime("2026-04-20T20:00:00");
         event.setAvailableSeats(10);
         event.setStatus("ACTIVE");
     }
 
     @Test
     void shouldCreateReservationSuccessfully() {
+        User user = new User("customer@example.com", null, "hash", "CUSTOMER");
         when(eventRepository.findByIdForUpdate(1)).thenReturn(Optional.of(event));
+        when(userRepository.findById(7L)).thenReturn(Optional.of(user));
         when(reservationRepository.save(any(Reservation.class))).thenAnswer(invocation -> {
             Reservation reservation = invocation.getArgument(0);
             reservation.setId(99L);
@@ -62,6 +76,7 @@ class ReservationServiceTest {
 
         verify(eventRepository).save(event);
         verify(reservationRepository).save(any(Reservation.class));
+        verify(notificationService).sendBookingConfirmation(eq("customer@example.com"), eq("SOEN Concert"), anyLong(), any());
     }
 
     @Test


### PR DESCRIPTION
### Summary
This PR implements email notifications and notification logging for reservation and admin cancellation flows.

### Scope
- Added mail support dependency
- Added SMTP config placeholders (Mailtrap-ready)
- Added notification persistence
- Added notification service
- Added mail bean config to keep app/test context stable
- Wired notification triggers
- Added/updated tests

### Functional Requirement Mapping
FR-5: Digital confirmations (booking confirmation email)
FR-6: Admin event management notification behavior (event cancellation emails)

### Validation
Executed in WSL:
- `./gradlew test --tests com.soen345.meow.NotificationServiceTest --tests com.soen345.meow.AdminEventControllerNotificationTest --tests com.soen345.meow.ReservationServiceTest`
- `./gradlew test`

Both passed.

### Notes
- Mail credentials are parameterized via:
  - `MAILTRAP_USERNAME`
  - `MAILTRAP_PASSWORD`
- Placeholder defaults are currently set for local/dev safety.
